### PR TITLE
Add apply action and deployments to Cloud Run and API Gateway

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -1,0 +1,54 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Run the registry tool
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # each 12:00 UTC
+  push:
+    branches: [ main ]
+    tags: [ 'v*.*.*' ] # semver release
+
+jobs:
+
+  registry-apply:
+    runs-on: ubuntu-22.04
+
+    env:
+      workload_identity_provider: "projects/442894430397/locations/global/workloadIdentityPools/registry/providers/registry"
+      service_account: "registry-editor@timbx-me.iam.gserviceaccount.com"
+
+    permissions:
+      id-token: write # required for requesting the JWT
+      contents: read # required for actions/checkout
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Google Cloud auth
+      uses: google-github-actions/auth@v1
+      with:
+        workload_identity_provider: ${{ env.workload_identity_provider }}
+        service_account: ${{ env.service_account }}
+    - name: Set up Google Cloud SDK
+      uses: google-github-actions/setup-gcloud@v1
+    - uses: apigee/registry/.github/actions/setup-registry@main
+      with:
+        name: cloud
+        project: ${{ env.GCP_PROJECT }} # set by setup-gcloud action
+        address: apigeeregistry.googleapis.com:443
+        insecure: false
+        token-source: gcloud auth print-access-token
+    - name: Apply API to cloud registry
+      run: registry apply -f api -R

--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -15,20 +15,13 @@
 name: Run the registry tool
 
 on:
-  schedule:
-    - cron: '0 0 * * *' # each 12:00 UTC
   push:
     branches: [ main ]
-    tags: [ 'v*.*.*' ] # semver release
 
 jobs:
 
   registry-apply:
     runs-on: ubuntu-22.04
-
-    env:
-      workload_identity_provider: "projects/442894430397/locations/global/workloadIdentityPools/registry/providers/registry"
-      service_account: "registry-editor@timbx-me.iam.gserviceaccount.com"
 
     permissions:
       id-token: write # required for requesting the JWT
@@ -39,8 +32,8 @@ jobs:
     - name: Set up Google Cloud auth
       uses: google-github-actions/auth@v1
       with:
-        workload_identity_provider: ${{ env.workload_identity_provider }}
-        service_account: ${{ env.service_account }}
+        workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ vars.SERVICE_ACCOUNT }}
     - name: Set up Google Cloud SDK
       uses: google-github-actions/setup-gcloud@v1
     - uses: apigee/registry/.github/actions/setup-registry@main

--- a/.github/workflows/composite/build-push/action.yml
+++ b/.github/workflows/composite/build-push/action.yml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/composite/build-push/action.yml
+++ b/.github/workflows/composite/build-push/action.yml
@@ -1,0 +1,70 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Build and Push image'
+description: 'Composite action to generate registry images'
+inputs:
+  registry:
+    description: 'Image registry to use'
+    required: true
+    default: 'ghcr.io'
+  username:
+    description: 'Username to the image registry'
+    required: true
+  password:
+    description: 'Password for the image registry'
+    required: true
+  image:
+    description: 'Docker image to build'
+    required: true
+  context:
+    description: 'Context to docker build'
+    required: true
+    default: "."
+  file:
+    description: 'Path to the docker file relative to context'
+    required: true
+  build-args:
+    description: 'Build arguments for docker'
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - name: Log into registry ${{ env.REGISTRY }}
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+    - name: Extract Docker metadata
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: ${{ inputs.registry }}/${{ inputs.image }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=tag
+          type=schedule,pattern=nightly
+          type=raw,latest
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v4
+      with:
+        context: ${{ inputs.context }}
+        file: ${{ inputs.file }}
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        build-args: ${{ inputs.build-args }}

--- a/.github/workflows/composite/build-push/action.yml
+++ b/.github/workflows/composite/build-push/action.yml
@@ -41,6 +41,12 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    # https://github.com/docker/setup-buildx-action
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
     - name: Log into registry ${{ env.REGISTRY }}
       if: github.event_name != 'pull_request'
       uses: docker/login-action@v2
@@ -58,7 +64,6 @@ runs:
           type=ref,event=tag
           type=schedule,pattern=nightly
           type=raw,latest
-
     - name: Build and push Docker image
       uses: docker/build-push-action@v4
       with:
@@ -67,4 +72,5 @@ runs:
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        platforms: linux/amd64,linux/arm64
         build-args: ${{ inputs.build-args }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,46 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Publish docker images
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # each 12:00 UTC
+  push:
+    branches: [ main ]
+    tags: [ 'v*.*.*' ] # semver release
+  pull_request:
+    branches: [ main ]
+
+env:
+  REGISTRY: ghcr.io
+  USERNAME: ${{ github.actor }}
+  PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+  DOCKER_REPOSITORY_OWNER: ${{github.repository_owner}}
+
+jobs:
+
+  build-container:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - uses: ./.github/workflows/composite/build-push
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ env.USERNAME }}
+        password: ${{ env.PASSWORD }}
+        image: ${{ env.DOCKER_REPOSITORY_OWNER }}/bookstore-server
+        context: .
+        file: Dockerfile

--- a/README.md
+++ b/README.md
@@ -4,6 +4,126 @@ This repository contains a tiny implementation of the Bookstore gRPC service
 that can be deployed to Cloud Run or another platform to provide a simple
 target server that can be used to test gRPC API management systems and clients.
 
+## Developing the Bookstore API with the API Registry
+
+Here's a brief exercise that shows how the registry can be used to track and
+assist in the process of deploying and managing an instance of the Bookstore
+API.
+
+### Configure your environment.
+
+This demonstration uses the `gcloud` and `registry` tools,
+along with `jq` and `yq` for processing JSON and YAML, respectively. 
+- [`gcloud` installation instructions](https://cloud.google.com/sdk/docs/install)
+- [`registry` installation instructions](https://github.com/apigee/registry#the-registry-tool)
+- [`jq` installation instructions](https://stedolan.github.io/jq/download/)
+- [`yq` installation instructions](https://github.com/mikefarah/yq/#install)
+
+To aid in the following, set the `PROJECT` and `REGION` environment variables
+to your Google Cloud project and the location where you would like to create
+your demo instances. This region does not need to be the one where your
+registry is running.
+
+If necessary, log into `gcloud`.
+
+```
+gcloud auth login
+```
+
+Next, configure `gcloud` with your project and region.
+
+```
+gcloud config set project $PROJECT
+gcloud config set run/region $REGION
+```
+
+Configure the `registry` tool to work with your API Hub and registry.
+
+```
+registry config configurations create hosted
+registry config set address apigeeregistry.googleapis.com:443
+registry config set insecure false
+registry config set location global
+registry config set project $PROJECT
+```
+
+Note that your registry can be in a different project than the one where you
+create your demo instances. If so, use `registry config set project` to point
+to the appropriate project.
+
+### 1. Register the Bookstore API.
+
+The [api](/api) directory contains API specifications and `registry` metadata to
+describe the Bookstore API. This can be added to API Hub with the following
+command:
+
+```
+registry apply -f api -R
+```
+
+Note that we are loading a single API description that is written in the
+Protocol Buffers language in multiple files. The `api` directory includes
+the top-level definition of the API (`api/examples/bookstore/v1/bookstore.proto`)
+and all dependencies that are required to compile it (in`api/google`). The
+registry tool will collect all of these into a multifile Zip archive which
+is uploaded as the spec body.
+
+### 2. Deploy your service backend.
+
+Let's deploy our backend on [Cloud Run](https://cloud.google.com/run). The
+following will build and deploy your service in the configured region.
+
+```
+gcloud run deploy bookstore --source .
+```
+
+Alternately, you can deploy your backend with the button below:
+
+[![Run on Google Cloud](https://deploy.cloud.run/button.svg)](https://deploy.cloud.run)
+
+### 3. Register your backend deployment.
+
+Now let's create an entry in API Hub for the backend that we've just deployed.
+
+```
+# Generate a deployment YAML with information from gcloud.
+./tools/GENERATE-BACKEND-DEPLOYMENT.sh
+
+# Apply the deployment YAML to the registry.
+registry apply -f backend-deployment.yaml
+```
+
+### 4. Deploy an API Gateway.
+
+Next we can create an [API Gateway](https://cloud.google.com/api-gateway) proxy
+for our backend API.
+
+```
+./tools/DEPLOY-APIGATEWAY.sh
+```
+
+### 5. Register your API Gateway deployment.
+
+Let's add this gateway to our registry.
+
+```
+# Generate a deployment YAML with information from gcloud.
+./tools/GENERATE-APIGATEWAY-DEPLOYMENT.sh
+
+# Apply the deployment YAML to the registry.
+registry apply -f gateway-deployment.yaml
+```
+
+### 6. Clean up.
+
+```
+# Delete the backend and gateway resources.
+./tools/CLEANUP.sh
+
+# Remove the bookstore entries from the registry.
+registry delete apis/bookstore -f
+```
+
 ## Disclaimer
 
 This demonstration is not an officially supported Google product.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ for our backend API.
 ./tools/DEPLOY-APIGATEWAY.sh
 ```
 
+Note that this step requires `registry-experimental` and `protoc`.
+
 ### 5. Register your API Gateway deployment.
 
 Let's add this gateway to our registry.

--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@ target server that can be used to test gRPC API management systems and clients.
 
 ## Developing the Bookstore API with the API Registry
 
-Here's a brief exercise that shows how the registry can be used to track and
-assist in the process of deploying and managing an instance of the Bookstore
-API.
+Here's a brief exercise that shows how the API Registry can be used to track
+and assist in the process of deploying and managing an instance of the
+Bookstore API.
 
 ### Configure your environment.
 
-This demonstration uses the `gcloud` and `registry` tools,
-along with `jq` and `yq` for processing JSON and YAML, respectively. 
+This demonstration uses the `gcloud` and `registry` tools, along with `jq` and
+`yq` for processing JSON and YAML, respectively.
+
 - [`gcloud` installation instructions](https://cloud.google.com/sdk/docs/install)
 - [`registry` installation instructions](https://github.com/apigee/registry#the-registry-tool)
 - [`jq` installation instructions](https://stedolan.github.io/jq/download/)
@@ -53,8 +54,8 @@ to the appropriate project.
 
 ### 1. Register the Bookstore API.
 
-The [api](/api) directory contains API specifications and `registry` metadata to
-describe the Bookstore API. This can be added to API Hub with the following
+The [api](/api) directory contains API specifications and `registry` metadata
+to describe the Bookstore API. This can be added to API Hub with the following
 command:
 
 ```
@@ -62,11 +63,11 @@ registry apply -f api -R
 ```
 
 Note that we are loading a single API description that is written in the
-Protocol Buffers language in multiple files. The `api` directory includes
-the top-level definition of the API (`api/examples/bookstore/v1/bookstore.proto`)
+Protocol Buffers language in multiple files. The `api` directory includes the
+top-level definition of the API (`api/examples/bookstore/v1/bookstore.proto`)
 and all dependencies that are required to compile it (in`api/google`). The
-registry tool will collect all of these into a multifile Zip archive which
-is uploaded as the spec body.
+registry tool will collect all of these into a multifile Zip archive which is
+uploaded as the spec body.
 
 ### 2. Deploy your service backend.
 

--- a/api/info.yaml
+++ b/api/info.yaml
@@ -19,6 +19,16 @@ metadata:
 data:
   displayName: Bookstore Example API
   description: A simple Google Example Library API.
+  versions:
+    - metadata:
+        name: v1
+      data:
+        specs:
+        - metadata:
+            name: protos
+          data:
+            fileName: protos.zip 
+            mimeType: application/x.protobuf+zip
   artifacts:
     - kind: ReferenceList
       metadata:

--- a/api/info.yaml
+++ b/api/info.yaml
@@ -16,13 +16,31 @@ apiVersion: apigeeregistry/v1
 kind: API
 metadata:
   name: bookstore
+  labels:
+    apihub-business-unit: demo
+    apihub-lifecycle: develop
+    apihub-style: apihub-grpc
+    apihub-target-users: public
+    apihub-team: demo
+    categories: reference
+    provider: apihub-demo
+    source: bookstore
+  annotations:
+    apihub-primary-contact: apigee-apihub-demo@google.com
+    apihub-primary-contact-description: Apigee API Hub demo managers
 data:
-  displayName: Bookstore Example API
-  description: A simple Google Example Library API.
+  displayName: Bookstore API
+  description: Bookstore is a gRPC demonstration API.  It provides a few simple methods for accessing and modifying an inventory of books.
+  recommendedVersion: v1
   versions:
     - metadata:
         name: v1
+        labels:
+          source: petstore
       data:
+        displayName: v1
+        state: production
+        primarySpec: protos
         specs:
         - metadata:
             name: protos

--- a/tools/CLEANUP.sh
+++ b/tools/CLEANUP.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Copyright 2023 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+gcloud api-gateway gateways delete bookstore --location $REGION
+gcloud api-gateway api-configs delete bookstore --api bookstore
+gcloud api-gateway apis delete bookstore 
+
+gcloud run services delete bookstore

--- a/tools/DEPLOY-BACKEND.sh
+++ b/tools/DEPLOY-BACKEND.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2023 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+gcloud run deploy bookstore --source .

--- a/tools/DEPLOY-GATEWAY.sh
+++ b/tools/DEPLOY-GATEWAY.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# Copyright 2023 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+
+API_ID=bookstore
+DEPLOYMENT_ID=backend
+
+ADDRESS=$(registry get apis/${API_ID}/deployments/${DEPLOYMENT_ID} -o raw | jq .[0].endpointUri -r)
+ADDRESS=${ADDRESS#https://}
+
+SPEC=$(registry get apis/${API_ID}/deployments/${DEPLOYMENT_ID} -o raw | jq .[0].apiSpecRevision -r)
+
+PROJECT=$(gcloud config get project)
+REGION=$(gcloud config get run/region)
+
+cat > api_config.yaml <<EOF
+# The configuration schema is defined by the service.proto file.
+# https://github.com/googleapis/googleapis/blob/master/google/api/service.proto
+
+type: google.api.Service
+config_version: 3
+name: "*.apigateway.$PROJECT.cloud.goog"
+title: API Gateway + Cloud Run gRPC
+apis:
+  - name: examples.bookstore.v1.Bookstore
+usage:
+  rules:
+  - selector: "*"
+    allow_unregistered_calls: true
+backend:
+  rules:
+  - selector: "*"
+    address: grpcs://$ADDRESS
+EOF
+
+registry-experimental compute descriptor apis/${API_ID}/versions/v1/specs/protos
+registry get apis/${API_ID}/versions/v1/specs/protos/artifacts/descriptor -o contents > descriptor.pb
+
+gcloud api-gateway api-configs create ${API_ID} --api=${API_ID} --project=${PROJECT} --grpc-files=descriptor.pb,api_config.yaml
+gcloud api-gateway gateways create ${API_ID} --api=${API_ID} --api-config=${API_ID} --location=${REGION} --project=${PROJECT}
+

--- a/tools/GENERATE-APICONFIG.sh
+++ b/tools/GENERATE-APICONFIG.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+PROJECT=$(gcloud config get project)
+ADDRESS=$(gcloud run services describe bookstore --format "value(status.url)")
+ADDRESS=${ADDRESS#https://}
+cat > api_config.yaml <<EOF
+# The configuration schema is defined by the service.proto file.
+# https://github.com/googleapis/googleapis/blob/master/google/api/service.proto
+
+type: google.api.Service
+config_version: 3
+name: "*.apigateway.$PROJECT.cloud.goog"
+title: API Gateway + Cloud Run gRPC
+apis:
+  - name: examples.bookstore.v1.Bookstore
+usage:
+  rules:
+  - selector: "*"
+    allow_unregistered_calls: true
+backend:
+  rules:
+  - selector: "*"
+    address: grpcs://$ADDRESS
+EOF

--- a/tools/GENERATE-BACKEND-DEPLOYMENT.sh
+++ b/tools/GENERATE-BACKEND-DEPLOYMENT.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Copyright 2023 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+
+PROJECT=$(gcloud config get project)
+REGION=$(gcloud config get run/region)
+REVISION=$(registry get projects/${PROJECT}/locations/global/apis/bookstore/versions/v1/specs/protos -o raw | jq .[0].revisionId -r)
+ADDRESS=$(gcloud run services describe bookstore --format "value(status.url)")
+
+cat > backend-deployment.yaml <<EOF
+apiVersion: apigeeregistry/v1
+kind: Deployment
+metadata:
+  name: backend
+  parent: apis/bookstore
+  labels:
+    platform: cloudrun
+    apihub-gateway: apihub-unmanaged
+  annotations:
+    apihub-external-channel-name: Cloud Run
+    region: $REGION
+    project: $PROJECT
+data:
+  displayName: Backend
+  description: The backend deployment of the Bookstore API
+  apiSpecRevision: v1/specs/protos@$REVISION
+  endpointURI: $ADDRESS
+  externalChannelURI: https://console.cloud.google.com/run/detail/$REGION/bookstore/metrics?project=$PROJECT
+  intendedAudience: Internal
+EOF

--- a/tools/GENERATE-GATEWAY-DEPLOYMENT.sh
+++ b/tools/GENERATE-GATEWAY-DEPLOYMENT.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Copyright 2023 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+PROJECT=$(gcloud config get project)
+REGION=$(gcloud config get run/region)
+ENDPOINT_ADDRESS=https://$(gcloud api-gateway gateways describe bookstore --location ${REGION} --format "value(defaultHostname)")
+SERVICE=$(gcloud api-gateway apis describe bookstore --format "value(managedService)")
+
+SPEC_REVISION=$(registry get projects/${PROJECT}/locations/global/apis/bookstore/deployments/backend -o raw | jq .[0].apiSpecRevision -r)
+SPEC_REVISION=${SPEC_REVISION#projects/${PROJECT}/locations/global/apis/bookstore/versions/}
+
+cat > gateway-deployment.yaml <<EOF
+apiVersion: apigeeregistry/v1
+kind: Deployment
+metadata:
+  name: gateway
+  parent: apis/bookstore
+  labels:
+    platform: apigateway
+    apihub-gateway: apihub-google-cloud-api-gateway
+  annotations:
+    apihub-external-channel-name: API Gateway
+    region: $REGION
+    project: $PROJECT
+data:
+  displayName: Gateway
+  description: An API Gateway deployment of the Bookstore API
+  apiSpecRevision: $SPEC_REVISION
+  endpointURI: $ENDPOINT_ADDRESS
+  externalChannelURI: https://console.cloud.google.com/api-gateway/api/bookstore/servicename/$SERVICE/overview?project=$PROJECT
+  intendedAudience: Public
+EOF


### PR DESCRIPTION
This generally follows the example in https://github.com/apigee-apihub-demo/petstore, including a GitHub Action that applies the API spec to the main project registry.

Closes #3 #4 and #6.