### PR TITLE
remove "apihub-" from apihub-gateway label value

### DIFF
--- a/tools/GENERATE-GATEWAY-DEPLOYMENT.sh
+++ b/tools/GENERATE-GATEWAY-DEPLOYMENT.sh
@@ -31,7 +31,7 @@ metadata:
   parent: apis/bookstore
   labels:
     platform: apigateway
-    apihub-gateway: apihub-google-cloud-api-gateway
+    apihub-gateway: google-cloud-api-gateway
   annotations:
     apihub-external-channel-name: API Gateway
     region: $REGION


### PR DESCRIPTION
Putting an "apihub-" prefix on the label value seems inappropriate.